### PR TITLE
fix: schemas type does not support len() method

### DIFF
--- a/database2prompt/database/processing/database_processor.py
+++ b/database2prompt/database/processing/database_processor.py
@@ -21,7 +21,7 @@ class DatabaseProcessor():
     def process_data(self) -> dict:
         """Take the information of the database and process it for markdown insertion"""
 
-        schemas = self.database.list_schemas()
+        schemas = list(self.database.list_schemas())
         if (len(schemas) != 0):
             self.__iterate_tables(schemas)
         views = self.database.list_views()


### PR DESCRIPTION
Quando rodei o database2prompt pela primeira vez, recebi o erro "TypeError: object of type 'filter' has no len()", como mostra a imagem abaixo:

<img width="930" alt="Screenshot 2025-03-06 at 11 23 48" src="https://github.com/user-attachments/assets/8276bc2a-9770-4454-b5c4-59a600bd75b4" />

Para resolvê-lo, eu converti a o objeto de tipo "filter" para uma lista, usando o método list() e então consegui prosseguir no database2prompt.