### PR TITLE
feat: return a sample data from the db in the output 

### DIFF
--- a/database2prompt/database/core/database_strategy.py
+++ b/database2prompt/database/core/database_strategy.py
@@ -31,3 +31,7 @@ class DatabaseStrategy(ABC):
     @abstractmethod
     def create_materialized_view(self, query):
         pass
+
+    @abstractmethod
+    def get_table_sample(self, table: str, schema: str, limit: int = 5) -> List[Dict]:
+        pass

--- a/database2prompt/database/core/database_strategy.py
+++ b/database2prompt/database/core/database_strategy.py
@@ -33,5 +33,5 @@ class DatabaseStrategy(ABC):
         pass
 
     @abstractmethod
-    def get_table_sample(self, table: str, schema: str, limit: int = 5) -> List[Dict]:
+    def get_table_sample(self, table: str, schema: str, limit: int = 3) -> List[Dict]:
         pass

--- a/database2prompt/database/pgsql/postgresql_strategy.py
+++ b/database2prompt/database/pgsql/postgresql_strategy.py
@@ -69,7 +69,7 @@ class PostgreSQLStrategy(DatabaseStrategy):
             result = connection.execute(text(sql))
             connection.commit()
 
-    def get_table_sample(self, table: str, schema: str, limit: int = 5) -> List[Dict]:
+    def get_table_sample(self, table: str, schema: str, limit: int = 3) -> List[Dict]:
         query = f"""
             SELECT *
             FROM {schema}.{table}

--- a/database2prompt/database/pgsql/postgresql_strategy.py
+++ b/database2prompt/database/pgsql/postgresql_strategy.py
@@ -1,5 +1,6 @@
 from sqlalchemy import create_engine, inspect, text, MetaData, Table
 from sqlalchemy.orm import sessionmaker
+from typing import List, Dict
 
 from database2prompt.database.core.database_strategy import DatabaseStrategy
 from database2prompt.database.core.database_config import DatabaseConfig
@@ -67,3 +68,14 @@ class PostgreSQLStrategy(DatabaseStrategy):
         with self.engine.connect() as connection:
             result = connection.execute(text(sql))
             connection.commit()
+
+    def get_table_sample(self, table: str, schema: str, limit: int = 5) -> List[Dict]:
+        query = f"""
+            SELECT *
+            FROM {schema}.{table}
+            LIMIT {limit}
+        """
+        
+        with self.engine.connect() as connection:
+            result = connection.execute(text(query))
+            return [dict(row._mapping) for row in result]

--- a/database2prompt/database/processing/database_processor.py
+++ b/database2prompt/database/processing/database_processor.py
@@ -91,11 +91,20 @@ class DatabaseProcessor():
                 table = self.database.table_object(table_name, schema_name)
                 fields = self.__get_processed_fields(table)
 
+                
+                try:
+                    sample_data = self.database.get_table_sample(table_name, schema_name)
+                except Exception as e:
+                    if verbose:
+                        print(f"Could not get sample data for {fully_qualified_name}: {str(e)}")
+                    sample_data = []
+
                 self.processed_info["tables"][fully_qualified_name] = {
                     "name": table_name,
                     "schema": schema_name,
                     "estimated_rows": all_estimated_rows.get(table_name),
-                    "fields": fields
+                    "fields": fields,
+                    "sample_data": sample_data
                 }
 
     def __get_processed_fields(self, table: Table):

--- a/database2prompt/json_generator/json_generator.py
+++ b/database2prompt/json_generator/json_generator.py
@@ -1,4 +1,17 @@
-from typing import Dict
+import json
+from typing import Any, Dict
+
+class DatabaseJSONEncoder(json.JSONEncoder):
+    """
+    Custom JSON encoder for database objects.
+    """
+    def default(self, obj: Any) -> Any:
+        # Para lidar com todos os possiveis tipos de dados diferentes vindos do sample_data
+        try:
+            return str(obj)
+        except Exception:
+            print(f"Error serializing object of type {type(obj)}: {obj}")   
+            return None
 
 class JsonGenerator:
     def __init__(self, database_info: dict):

--- a/database2prompt/json_generator/json_generator.py
+++ b/database2prompt/json_generator/json_generator.py
@@ -21,7 +21,8 @@ class JsonGenerator:
                 "table_name": table_name,
                 "schema": table_info["schema"],
                 "estimated_rows": table_info["estimated_rows"],
-                "columns": []
+                "columns": [],
+                "sample_data": table_info.get("sample_data", [])
             }
             
             # Process columns

--- a/database2prompt/json_generator/json_generator.py
+++ b/database2prompt/json_generator/json_generator.py
@@ -6,7 +6,7 @@ class DatabaseJSONEncoder(json.JSONEncoder):
     Custom JSON encoder for database objects.
     """
     def default(self, obj: Any) -> Any:
-        # Para lidar com todos os possiveis tipos de dados diferentes vindos do sample_data
+        # Para lidar com todos os possíveis tipos de dados diferentes vindos do sample_data
         try:
             return str(obj)
         except Exception:

--- a/database2prompt/main.py
+++ b/database2prompt/main.py
@@ -3,6 +3,13 @@ from database2prompt.database.core.database_params import DatabaseParams
 from database2prompt.database.core.database_config import DatabaseConfig
 from database2prompt.database.processing.database_processor import DatabaseProcessor
 import json
+from datetime import datetime
+
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        return super().default(obj)
 
 def main():
 
@@ -40,7 +47,7 @@ def main():
     # Generate JSON
     json_content = database_processor.database_to_prompt(output_format="json")
     with open("summary-database.json", "w", encoding="utf-8") as file:
-        json.dump(json_content, file, indent=2, ensure_ascii=False)
+        json.dump(json_content, file, indent=2, ensure_ascii=False, cls=DateTimeEncoder)
     print("JSON file generated: summary-database.json")
 
 if __name__ == "__main__":

--- a/database2prompt/main.py
+++ b/database2prompt/main.py
@@ -3,13 +3,9 @@ from database2prompt.database.core.database_params import DatabaseParams
 from database2prompt.database.core.database_config import DatabaseConfig
 from database2prompt.database.processing.database_processor import DatabaseProcessor
 import json
-from datetime import datetime
+from database2prompt.json_generator.json_generator import DatabaseJSONEncoder
 
-class DateTimeEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        return super().default(obj)
+
 
 def main():
 
@@ -47,7 +43,7 @@ def main():
     # Generate JSON
     json_content = database_processor.database_to_prompt(output_format="json")
     with open("summary-database.json", "w", encoding="utf-8") as file:
-        json.dump(json_content, file, indent=2, ensure_ascii=False, cls=DateTimeEncoder)
+        json.dump(json_content, file, indent=2, ensure_ascii=False, cls=DatabaseJSONEncoder)
     print("JSON file generated: summary-database.json")
 
 if __name__ == "__main__":

--- a/database2prompt/markdown/markdown_generator.py
+++ b/database2prompt/markdown/markdown_generator.py
@@ -30,6 +30,21 @@ class MarkdownGenerator:
                 md_content += f"    {column_key} {column_data["type"]} {column_data["default"]} {column_data["nullable"]},\n"
             md_content += ");\n"
             md_content += "```\n"
+
+            
+            if "sample_data" in table_data and table_data["sample_data"]:
+                md_content += "\n### Sample Data\n\n"
+                md_content += "```sql\n"
+                
+                headers = list(table_data["sample_data"][0].keys())
+                md_content += "| " + " | ".join(headers) + " |\n"
+                md_content += "| " + " | ".join(["---"] * len(headers)) + " |\n"
+                
+                
+                for row in table_data["sample_data"]:
+                    values = [str(row.get(header, "")) for header in headers]
+                    md_content += "| " + " | ".join(values) + " |\n"
+                md_content += "```\n"
         
         md_content += "\n"
         md_content += "# Views \n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "database2prompt"
-version = "0.1.5"
+version = "0.2.0"
 description = "Extract relevant metadata from databases and transform it into context for Retrieval-Augmented Generation (RAG) in generative AI applications."
 authors = [
     {name = "jose.neto",email = "jose.neto-ext@anbima.com.br"}

--- a/summary-database.json
+++ b/summary-database.json
@@ -29,6 +29,20 @@
           "nullable": true,
           "default": "DEFAULT CURRENT_TIMESTAMP"
         }
+      ],
+      "sample_data": [
+        {
+          "investor_id": 1,
+          "name": "John Smith",
+          "email": "john.smith@email.com",
+          "created_at": "2024-01-15T10:30:00"
+        },
+        {
+          "investor_id": 2,
+          "name": "Maria Garcia",
+          "email": "maria.garcia@email.com",
+          "created_at": "2024-02-01T14:20:00"
+        }
       ]
     },
     {
@@ -78,6 +92,26 @@
           "nullable": true,
           "default": null
         }
+      ],
+      "sample_data": [
+        {
+          "trade_id": 1,
+          "investor_id": 1,
+          "stock_id": 1,
+          "trade_date": "2024-03-15",
+          "quantity": 100,
+          "price_per_share": 150.50,
+          "trade_type": "BUY"
+        },
+        {
+          "trade_id": 2,
+          "investor_id": 2,
+          "stock_id": 2,
+          "trade_date": "2024-03-16",
+          "quantity": 50,
+          "price_per_share": 275.75,
+          "trade_type": "SELL"
+        }
       ]
     },
     {
@@ -114,6 +148,22 @@
           "type": "date",
           "nullable": true,
           "default": null
+        }
+      ],
+      "sample_data": [
+        {
+          "stock_id": 1,
+          "symbol": "AAPL",
+          "company_name": "Apple Inc.",
+          "sector": "Technology",
+          "listed_since": "1980-12-12"
+        },
+        {
+          "stock_id": 2,
+          "symbol": "MSFT",
+          "company_name": "Microsoft Corporation",
+          "sector": "Technology",
+          "listed_since": "1986-03-13"
         }
       ]
     }

--- a/summary-database.md
+++ b/summary-database.md
@@ -17,6 +17,14 @@ CREATE TABLE public.investors (
 );
 ```
 
+### Sample Data
+```sql
+| investor_id | name | email | created_at |
+| --- | --- | --- | --- |
+| 1 | John Smith | john.smith@email.com | 2024-01-15T10:30:00 |
+| 2 | Maria Garcia | maria.garcia@email.com | 2024-02-01T14:20:00 |
+```
+
 ## Table: public.trades
 - Estimated rows: -1
 
@@ -34,6 +42,14 @@ CREATE TABLE public.trades (
 );
 ```
 
+### Sample Data
+```sql
+| trade_id | investor_id | stock_id | trade_date | quantity | price_per_share | trade_type |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 1 | 1 | 2024-03-15 | 100 | 150.50 | BUY |
+| 2 | 2 | 2 | 2024-03-16 | 50 | 275.75 | SELL |
+```
+
 ## Table: public.stocks
 - Estimated rows: -1
 
@@ -47,6 +63,14 @@ CREATE TABLE public.stocks (
     sector varchar(100) None NULL,
     listed_since date None NULL,
 );
+```
+
+### Sample Data
+```sql
+| stock_id | symbol | company_name | sector | listed_since |
+| --- | --- | --- | --- | --- |
+| 1 | AAPL | Apple Inc. | Technology | 1980-12-12 |
+| 2 | MSFT | Microsoft Corporation | Technology | 1986-03-13 |
 ```
 
 # Views 


### PR DESCRIPTION
*Since no dedicated development branch was found, this pull request is based on the main branch.*

This PR introduces a new method: get_table_sample.
It allows retrieving a small sample of data from each table in the database, and includes it in the output of the library.

- Notes
A custom JSON encoder, DatabaseJSONEncoder, was created to handle various non-serializable data types that may be returned from the database.
To simplify serialization, any unsupported type is automatically converted to a string.

```
class DatabaseJSONEncoder(json.JSONEncoder):
    """
    Custom JSON encoder for database objects.
    """
    def default(self, obj: Any) -> Any:
        # Para lidar com todos os possiveis tipos de dados diferentes vindos do sample_data
        try:
            return str(obj)
        except Exception:
            print(f"Error serializing object of type {type(obj)}: {obj}")   
            return None
```