### PR TITLE
feat: loading from env by default

### DIFF
--- a/database2prompt/main.py
+++ b/database2prompt/main.py
@@ -9,14 +9,7 @@ from database2prompt.json_generator.json_generator import DatabaseJSONEncoder
 
 def main():
 
-    config = DatabaseConfig(
-    host="localhost",
-    port=5432,
-    user="admin",
-    password="admin",
-    database="database_agent",
-    schema="public"
-    )
+    config = DatabaseConfig().from_env()
 
     strategy = DatabaseFactory.run("pgsql", config)
     next(strategy.connection())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: postgres
     network_mode: host
     environment:
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: admin
-      POSTGRES_DB: database_agent
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     volumes:
       - postgres-data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## 📌 Summary

Database connection cofiguration is now set by default to take it from env, instead of having to hardcode into the code.

## ✅ Changes

- [x] Calls from.env() method instead
- [x] Uses environment variables at docker-compose.yml

## 🧪 How to Test

You can add a .env file with the configs examplified at .env.example, and test if the lib works as before. 

## 🔗 Related Issues

Closes https://github.com/orladigital/database2prompt/issues/30